### PR TITLE
Setting a Schema for DBUnit for Oracle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ target
 *~
 dependency-reduced-pom.xml
 
+
+.idea/
+*.iml

--- a/rdbms/src/main/java/eu/drus/jpa/unit/sql/dbunit/ext/Oracle10ConnectionFactory.java
+++ b/rdbms/src/main/java/eu/drus/jpa/unit/sql/dbunit/ext/Oracle10ConnectionFactory.java
@@ -1,12 +1,13 @@
 package eu.drus.jpa.unit.sql.dbunit.ext;
 
-import java.sql.Connection;
-
 import org.dbunit.DatabaseUnitException;
 import org.dbunit.database.DatabaseConfig;
 import org.dbunit.database.DatabaseConnection;
 import org.dbunit.database.IDatabaseConnection;
 import org.dbunit.ext.oracle.Oracle10DataTypeFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
 
 public class Oracle10ConnectionFactory implements DbUnitConnectionFactory {
 
@@ -17,10 +18,14 @@ public class Oracle10ConnectionFactory implements DbUnitConnectionFactory {
 
     @Override
     public IDatabaseConnection createConnection(final Connection connection) throws DatabaseUnitException {
-        final IDatabaseConnection dbUnitConnection = new DatabaseConnection(connection);
-        dbUnitConnection.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new Oracle10DataTypeFactory());
-
-        return dbUnitConnection;
+        try {
+            final IDatabaseConnection dbUnitConnection = new DatabaseConnection(connection, connection.getSchema());
+            dbUnitConnection.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new Oracle10DataTypeFactory());
+        
+            return dbUnitConnection;
+        } catch (SQLException e) {
+            throw new DatabaseUnitException(e);
+        }
     }
 
 }

--- a/rdbms/src/main/java/eu/drus/jpa/unit/sql/dbunit/ext/Oracle10ConnectionFactory.java
+++ b/rdbms/src/main/java/eu/drus/jpa/unit/sql/dbunit/ext/Oracle10ConnectionFactory.java
@@ -8,6 +8,7 @@ import org.dbunit.ext.oracle.Oracle10DataTypeFactory;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Optional;
 
 public class Oracle10ConnectionFactory implements DbUnitConnectionFactory {
 
@@ -18,14 +19,21 @@ public class Oracle10ConnectionFactory implements DbUnitConnectionFactory {
 
     @Override
     public IDatabaseConnection createConnection(final Connection connection) throws DatabaseUnitException {
-        try {
-            final IDatabaseConnection dbUnitConnection = new DatabaseConnection(connection, connection.getSchema());
-            dbUnitConnection.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new Oracle10DataTypeFactory());
+        Optional<String> schema = discoverSchema(connection);
+        // If no schema provided fall back to creating a connection without schema (Backwards compatibility)
+        final IDatabaseConnection dbUnitConnection
+            = schema.isPresent() ? new DatabaseConnection(connection, schema.get()) : new DatabaseConnection(connection);
         
-            return dbUnitConnection;
+        dbUnitConnection.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new Oracle10DataTypeFactory());
+        return dbUnitConnection;
+    }
+    
+    private static Optional<String> discoverSchema(final Connection connection) {
+        try {
+            return Optional.of(connection.getSchema());
         } catch (SQLException e) {
-            throw new DatabaseUnitException(e);
+            return Optional.empty();
         }
     }
-
+    
 }

--- a/rdbms/src/test/java/eu/drus/jpa/unit/sql/dbunit/ext/Oracle10ConnectionFactoryTest.java
+++ b/rdbms/src/test/java/eu/drus/jpa/unit/sql/dbunit/ext/Oracle10ConnectionFactoryTest.java
@@ -1,23 +1,27 @@
 package eu.drus.jpa.unit.sql.dbunit.ext;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-
-import java.sql.Connection;
-
 import org.dbunit.DatabaseUnitException;
 import org.dbunit.database.DatabaseConfig;
 import org.dbunit.database.IDatabaseConnection;
 import org.dbunit.dataset.datatype.DefaultDataTypeFactory;
+import org.hamcrest.core.Is;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import eu.drus.jpa.unit.sql.dbunit.ext.DbUnitConnectionFactory;
-import eu.drus.jpa.unit.sql.dbunit.ext.Oracle10ConnectionFactory;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class Oracle10ConnectionFactoryTest {
     private static final DbUnitConnectionFactory FACTORY = new Oracle10ConnectionFactory();
@@ -30,13 +34,47 @@ public class Oracle10ConnectionFactoryTest {
 
     @Test
     @Ignore("oracle jdbc required in classpath")
-    public void testCreateConnection() throws DatabaseUnitException {
+    public void testCreateConnectionNoSchemaAvailable() throws DatabaseUnitException, SQLException {
         // WHEN
-        final IDatabaseConnection connection = FACTORY.createConnection(mock(Connection.class));
+        Connection connectionMock = mock(Connection.class);
+        when(connectionMock.getSchema()).thenThrow(SQLException.class);
+        
+        final IDatabaseConnection connection = FACTORY.createConnection(connectionMock);
 
         // THEN
         assertThat(connection, notNullValue());
-
+        assertThat(connection.getSchema(), nullValue());
+        
+        final Object typeFactory = connection.getConfig().getProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY);
+        assertThat(typeFactory, notNullValue());
+        assertThat(typeFactory.getClass(), not(equalTo(DefaultDataTypeFactory.class)));
+    }
+    
+    
+    @Test
+    @Ignore("oracle jdbc required in classpath")
+    public void testCreateConnectionSchemaAvailableFromConnection() throws SQLException, DatabaseUnitException {
+        // WHEN
+        Connection connectionMock = mock(Connection.class);
+        when(connectionMock.getSchema()).thenReturn("schemaName");
+        DatabaseMetaData dbMetadataMock = mock(DatabaseMetaData.class);
+        when(dbMetadataMock.getIdentifierQuoteString()).thenReturn("'");
+        
+        when(connectionMock.getMetaData()).thenReturn(dbMetadataMock);
+        
+        // we Use same resultset mock for both catalog and schema proofing
+        ResultSet resultSetMock = mock(ResultSet.class);
+        doNothing().when(resultSetMock).close();
+        
+        when(dbMetadataMock.getCatalogs()).thenReturn(resultSetMock);
+        when(dbMetadataMock.getSchemas()).thenReturn(resultSetMock);
+        
+        final IDatabaseConnection connection = FACTORY.createConnection(connectionMock);
+    
+        // THEN
+        assertThat(connection, notNullValue());
+        assertThat(connection.getSchema(), Is.is("schemaName"));
+    
         final Object typeFactory = connection.getConfig().getProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY);
         assertThat(typeFactory, notNullValue());
         assertThat(typeFactory.getClass(), not(equalTo(DefaultDataTypeFactory.class)));


### PR DESCRIPTION
If a schema name is available for the connection it will be automatically set for dbunit. With that the DBUnit session will be bound to operate only on the specified schema and will not try to read the whole database